### PR TITLE
Fix lazy val support

### DIFF
--- a/src/main/scala-3/com/eed3si9n/eval/Eval.scala
+++ b/src/main/scala-3/com/eed3si9n/eval/Eval.scala
@@ -374,7 +374,11 @@ object Eval:
       tree match
         case tpd.ValDef(name, tpt, _)
             if isTopLevelModule(tree.symbol.owner) && isAcceptableType(tpt.tpe) =>
-          vals ::= name.mangledString
+          val str = name.mangledString
+          vals ::= (
+            if str.contains("$lzy") then str.take(str.indexOf("$"))
+            else str
+          )
         case t: tpd.Template   => this((), t.body)
         case t: tpd.PackageDef => this((), t.stats)
         case t: tpd.TypeDef    => this((), t.rhs)

--- a/src/test/scala-3/com/eed3si9n/eval/EvalTest.scala
+++ b/src/test/scala-3/com/eed3si9n/eval/EvalTest.scala
@@ -171,6 +171,21 @@ object EvalTest extends BasicTestSuite:
     }
   }
 
+  test("lazy val test") {
+    IO.withTemporaryDirectory { tempDir =>
+      val defs = (lazyValTestContent, 1 to 3) :: Nil
+      val res =
+        eval(tempDir.toPath).evalDefinitions(
+          defs,
+          new EvalImports(Nil),
+          "<defs>",
+          "scala.Int" :: Nil
+        )
+      assert(res.valNames.toSet == Set("x"))
+      assert(res.values(getClass.getClassLoader) == Seq(7))
+    }
+  }
+
   private[this] def hasErrors(line: Int, src: String) = {
     val errors = reporter.allErrors
     assert(errors.nonEmpty)
@@ -200,6 +215,10 @@ val p = {
   y
 
 val a: String = 9
+"""
+
+  lazy val lazyValTestContent = """
+lazy val x: Int = 7
 """
 
   lazy val IntType = "Int"


### PR DESCRIPTION
Problem
-------
By Typer phase it seems like lazy val is expanded out to `def x(): Int` and synthetic `val x$lzy1`,
which results in NoSuchMethod `x$lzy1`.

Solution
--------
Assume the naming convention and grab the part before `$`.