### PR TITLE
Align the initial runId with the one used in the compiler

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,19 +12,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            java: 8
-            distribution: zulu
-          - os: ubuntu-latest
             java: 17
             distribution: temurin
           - os: ubuntu-latest
             java: 21
             distribution: temurin
           - os: macos-latest
-            java: 11
+            java: 17
             distribution: temurin
           - os: windows-latest
-            java: 8
+            java: 17
             distribution: zulu
     runs-on: ${{ matrix.os }}
     env:

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val scalaVersions = Seq(
   // "3.5.2",
   // "3.4.3",
   // "3.3.5",
-  "3.8.0"
+  "3.8.1"
 )
 ThisBuild / version := "0.3.0-SNAPSHOT"
 ThisBuild / scalaVersion := scalaVersions.head

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
 import Dependencies._
 
 lazy val scalaVersions = Seq(
-  "3.6.4",
-  "3.5.2",
-  "3.4.3",
-  "3.3.5",
+  // "3.6.4",
+  // "3.5.2",
+  // "3.4.3",
+  // "3.3.5",
+  "3.8.0"
 )
 ThisBuild / version := "0.3.0-SNAPSHOT"
 ThisBuild / scalaVersion := scalaVersions.head

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.12.0

--- a/src/main/scala-3/com/eed3si9n/eval/Eval.scala
+++ b/src/main/scala-3/com/eed3si9n/eval/Eval.scala
@@ -8,6 +8,7 @@ import dotty.tools.dotc.core.Contexts.{ atPhase, Context }
 import dotty.tools.dotc.core.Decorators.toTermName
 import dotty.tools.dotc.core.{ Flags, Names, Phases, Symbols, Types }
 import dotty.tools.dotc.Driver
+import dotty.tools.dotc.core.Periods.*
 import dotty.tools.dotc.parsing.Parsers.Parser
 import dotty.tools.dotc.reporting.Reporter
 import dotty.tools.dotc.Run
@@ -57,6 +58,7 @@ class Eval(
       case Some((_, ctx)) => ctx
       case _              => sys.error(s"initialization failed for $options")
     val compileCtx2 = compileCtx1.fresh
+      .setPeriod(Period(2, 1)) // RunId 2 is the actually the first one in the compiler
       .setSetting(
         compileCtx1.settings.outputDir,
         outputDir
@@ -104,7 +106,6 @@ class Eval(
 
       override def extract(run: Run, unit: CompilationUnit)(using ctx: Context): String =
         atPhase(Phases.typerPhase.next):
-          ctx.setUsedBestEffortTasty()
           (new TypeExtractor).getType(unit.tpdTree)
 
       override def read(file: Path): String =

--- a/src/main/scala-3/com/eed3si9n/eval/Eval.scala
+++ b/src/main/scala-3/com/eed3si9n/eval/Eval.scala
@@ -13,7 +13,7 @@ import dotty.tools.dotc.reporting.Reporter
 import dotty.tools.dotc.Run
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.io.{ PlainDirectory, Directory, VirtualDirectory, VirtualFile }
-import dotty.tools.repl.AbstractFileClassLoader
+import dotty.tools.io.AbstractFileClassLoader
 import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Path, Paths, StandardOpenOption }
@@ -103,9 +103,9 @@ class Eval(
         EvalSourceFile(srcName, startLine, contents)
 
       override def extract(run: Run, unit: CompilationUnit)(using ctx: Context): String =
-        atPhase(Phases.typerPhase.next) {
+        atPhase(Phases.typerPhase.next):
+          ctx.setUsedBestEffortTasty()
           (new TypeExtractor).getType(unit.tpdTree)
-        }
 
       override def read(file: Path): String =
         String(Files.readAllBytes(file), StandardCharsets.UTF_8)
@@ -175,7 +175,7 @@ class Eval(
       override def extraHash: String = extraHash0
 
     val inter = evalCommon[Seq[String]](definitions.map(_._1), imports, tpeName = Some(""), ev)
-    EvalDefinitions(inter.loader, inter.generated, inter.enclosingModule, inter.extra.reverse)
+    EvalDefinitions(inter.loader, inter.generated, inter.enclosingModule, inter.extra.reverse.distinct)
 
   end evalDefinitions
 


### PR DESCRIPTION
I think that's a little better than using ctx.setUsedBestEffortTasty - this method is used by the compiler when it finds .betasty files in the classpath while using --with-best-effort-tasty. It causes ignoring more errors, which will cause issues here in the future and is meant as an IDE feature (although, not widely used yet...).